### PR TITLE
Add powershell script to check emulator startup

### DIFF
--- a/scripts/Check-EmulatorStartup.ps1
+++ b/scripts/Check-EmulatorStartup.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param
+(
+    [string]
+    $IpAddress = "localhost",
+
+    [System.TimeSpan]
+    $Timeout = $(New-TimeSpan -Minutes 2),
+
+    [int]
+    $Port = 8081
+)
+
+$ErrorActionPreference = "Stop"
+
+$StartTime = $(Get-Date)
+$EndTime = $StartTime + $Timeout
+$StatusCode = -1
+do
+{
+    $StatusCode = try
+    {
+        $(Invoke-WebRequest -Uri "https://$($IpAddress):$($Port)/_explorer/emulator.pem" -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop).BaseResponse.StatusCode
+    } catch [System.Net.WebException] {
+        $_.Exception.Response.StatusCode
+    }
+
+    if ($StatusCode -eq 200)
+    {
+        Write-Host "Emulator startup completed"
+        return
+    }
+
+    Start-Sleep -Seconds 2
+}
+while ($(Get-Date) -lt $EndTime)
+
+throw "Emulator not reachable within timeout $Timeout! Last retrieved status code: $StatusCode."


### PR DESCRIPTION
Adds powershell script similar to sh script to check if emulator startup completed by pinging emulator cert url.

Here's example output when startup fails (or emulator isn't running):

```
PS [redacted]> .\Check-EmulatorStartup.ps1 -Timeout $(New-TimeSpan -Seconds 30)
Emulator not reachable within timeout 00:00:30! Last retrieved status code: .
At C:\Repos\Mwc\aspaas\Deployment\scripts\Onebox\Check-EmulatorStartup.ps1:38 char:1
+ throw "Emulator not reachable within timeout $Timeout! Last retrieved ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Emulator not re... status code: .:String) [], RuntimeException
    + FullyQualifiedErrorId : Emulator not reachable within timeout 00:00:30! Last retrieved status code: .
```

Here's example output when startup succeeds:

```
PS [redacted]> .\Check-EmulatorStartup.ps1 -Timeout $(New-TimeSpan -Seconds 30)
Emulator startup completed
```