### PR TITLE
Add demo of change feed and hierarchical partition key in vnext emulator sample code

### DIFF
--- a/vnext/code-samples/dotnet/src/cosmosdb-vnext-test/Program.cs
+++ b/vnext/code-samples/dotnet/src/cosmosdb-vnext-test/Program.cs
@@ -19,9 +19,6 @@ public class TestDocument
 
     [JsonProperty("city")]
     public string City { get; set; }
-
-    [JsonProperty("ttl")]
-    public int TimeToLive { get; set; }
 }
 
 public class CosmosDbDemo
@@ -92,7 +89,7 @@ public class CosmosDbDemo
         await QueryAllDocumentsAsync(container);
 
         Console.WriteLine("\nUpdating document...");
-        await UpdateDocumentAndVerifyAsync(container, "document1", partitionKey1, "Chicago");
+        await UpdateDocumentAndVerifyAsync(container, "document1", partitionKey1, null); //"Chicago"
 
         Console.WriteLine("\nUpsert new document...");
         await UpsertDocumentAndVerifyAsync(container, "document3", "field1", partitionKey2, "New Orleans");
@@ -106,8 +103,14 @@ public class CosmosDbDemo
         Console.WriteLine("Reading all documents...");
         await QueryAllDocumentsAsync(container);
 
+        Console.WriteLine("\nQuerying documents with order by...");
+        await QueryDocumentsWithOrderByAsync(container);
+
         Console.WriteLine("\nDeleting document...");
         await DeleteDocumentAndVerifyAsync(container, "document1", partitionKey1);
+
+        Console.WriteLine("\nRunning Change Feed Demo...");
+        await RunChangeFeedDemoAsync(container);
 
         Console.WriteLine("Cleaning up...");
         await database.DeleteAsync();
@@ -123,20 +126,15 @@ public class CosmosDbDemo
 
     private async Task<Container> CreateContainerAsync(Database database, string containerName)
     {
-        // Create a new container with a partition key
+        // Create a new container with hierarchical partition keys
         ContainerProperties containerProperties = new ContainerProperties
         {
             Id = containerName,
-            PartitionKeyPath = "/pk",  // Note: this path must match a property in your document
-            IndexingPolicy = new IndexingPolicy
-            {
-                Automatic = true,
-                IndexingMode = IndexingMode.Consistent
-            }
+            PartitionKeyPaths = new List<string> { "/pk", "/queryfield" }  // Hierarchical partition key
         };
 
         ContainerResponse containerResponse = await database.CreateContainerIfNotExistsAsync(containerProperties);
-        Console.WriteLine($"Container created with status: {containerResponse.StatusCode}");
+        Console.WriteLine($"Container created with hierarchical partition keys - Status: {containerResponse.StatusCode}");
         return containerResponse.Container;
     }
 
@@ -150,8 +148,14 @@ public class CosmosDbDemo
             City = city
         };
 
-        ItemResponse<TestDocument> response = await container.CreateItemAsync(document, new PartitionKey(partitionKey));
-        Console.WriteLine($"Created document {id} - Status: {response.StatusCode}");
+        // Create hierarchical partition key
+        PartitionKey hierarchicalPK = new PartitionKeyBuilder()
+            .Add(partitionKey)
+            .Add(queryField)
+            .Build();
+
+        ItemResponse<TestDocument> response = await container.CreateItemAsync(document, hierarchicalPK);
+        Console.WriteLine($"Created document {id} with hierarchical partition key [{partitionKey}, {queryField}] - Status: {response.StatusCode}");
         return document;
     }
 
@@ -161,36 +165,63 @@ public class CosmosDbDemo
         
         try
         {
-            // First read the existing item
-            ItemResponse<TestDocument> readResponse = await container.ReadItemAsync<TestDocument>(
-                id: id,
-                partitionKey: new PartitionKey(partitionKey)
-            );
+            // We need to determine the queryfield value to build the correct hierarchical partition key
+            // First, let's query for the document to get its current queryfield value
+            string sqlQuery = "SELECT * FROM c WHERE c.id = @id AND c.pk = @pk";
+            QueryDefinition queryDefinition = new QueryDefinition(sqlQuery)
+                .WithParameter("@id", id)
+                .WithParameter("@pk", partitionKey);
             
-            TestDocument existingDocument = readResponse.Resource;
-            Console.WriteLine($"Retrieved document: Id={existingDocument.Id}, City={existingDocument.City}");
+            TestDocument existingDocument = null;
+            using (var iterator = container.GetItemQueryIterator<TestDocument>(queryDefinition))
+            {
+                var response = await iterator.ReadNextAsync();
+                existingDocument = response.FirstOrDefault();
+            }
+            
+            if (existingDocument == null)
+            {
+                Console.WriteLine($"Document with id {id} not found!");
+                return;
+            }
+            
+            Console.WriteLine($"Retrieved document: Id={existingDocument.Id}, City={existingDocument.City}, Queryfield={existingDocument.Queryfield}");
+            
+            // Create hierarchical partition key using existing values
+            PartitionKey hierarchicalPK = new PartitionKeyBuilder()
+                .Add(partitionKey)
+                .Add(existingDocument.Queryfield)
+                .Build();
             
             // Update the property
-            existingDocument.City = newCity;
+            existingDocument.City = null;
+            existingDocument.Queryfield = null;
             
             // Replace the item with the updated document
             ItemResponse<TestDocument> updateResponse = await container.ReplaceItemAsync(
                 item: existingDocument,
                 id: id,
-                partitionKey: new PartitionKey(partitionKey)
+                partitionKey: hierarchicalPK
             );
             
             Console.WriteLine($"Updated document - Status: {updateResponse.StatusCode}");
             
-            // Query to verify the update
+            // Query to verify the update (since queryfield is now null, we need to find it differently)
             Console.WriteLine("Verifying update by querying the document:");
-            ItemResponse<TestDocument> verifyResponse = await container.ReadItemAsync<TestDocument>(
-                id: id,
-                partitionKey: new PartitionKey(partitionKey)
-            );
+            string verifyQuery = "SELECT * FROM c WHERE c.id = @id AND c.pk = @pk";
+            QueryDefinition verifyQueryDef = new QueryDefinition(verifyQuery)
+                .WithParameter("@id", id)
+                .WithParameter("@pk", partitionKey);
             
-            TestDocument updatedDocument = verifyResponse.Resource;
-            Console.WriteLine($"Verified document: Id={updatedDocument.Id}, City={updatedDocument.City}");
+            using (var iterator = container.GetItemQueryIterator<TestDocument>(verifyQueryDef))
+            {
+                var response = await iterator.ReadNextAsync();
+                var updatedDocument = response.FirstOrDefault();
+                if (updatedDocument != null)
+                {
+                    Console.WriteLine($"Verified document: Id={updatedDocument.Id}, City={updatedDocument.City}, Queryfield={updatedDocument.Queryfield}");
+                }
+            }
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
@@ -200,7 +231,7 @@ public class CosmosDbDemo
 
     private async Task UpsertDocumentAndVerifyAsync(Container container, string id, string queryField, string partitionKey, string city)
     {
-        Console.WriteLine($"Upserting document {id} with partition key {partitionKey}");
+        Console.WriteLine($"Upserting document {id} with hierarchical partition key [{partitionKey}, {queryField}]");
         
         try
         {
@@ -210,14 +241,19 @@ public class CosmosDbDemo
                 Id = id,
                 Queryfield = queryField,
                 PartitionKey = partitionKey,
-                City = city,
-                TimeToLive = 3600  // Set TTL to 1 hour (3600 seconds)
+                City = city
             };
+            
+            // Create hierarchical partition key
+            PartitionKey hierarchicalPK = new PartitionKeyBuilder()
+                .Add(partitionKey)
+                .Add(queryField)
+                .Build();
             
             // Upsert the document (creates if doesn't exist, or replaces if it does)
             ItemResponse<TestDocument> upsertResponse = await container.UpsertItemAsync(
                 item: document,
-                partitionKey: new PartitionKey(partitionKey)
+                partitionKey: hierarchicalPK               
             );
             
             Console.WriteLine($"Upserted document - Status: {upsertResponse.StatusCode}");
@@ -226,7 +262,7 @@ public class CosmosDbDemo
             Console.WriteLine("Verifying upsert by reading the document:");
             ItemResponse<TestDocument> verifyResponse = await container.ReadItemAsync<TestDocument>(
                 id: id,
-                partitionKey: new PartitionKey(partitionKey)
+                partitionKey: hierarchicalPK
             );
             
             TestDocument upsertedDocument = verifyResponse.Resource;
@@ -245,10 +281,35 @@ public class CosmosDbDemo
         
         try
         {
+            // First find the document to get its queryfield value for the hierarchical partition key
+            string sqlQuery = "SELECT * FROM c WHERE c.id = @id AND c.pk = @pk";
+            QueryDefinition queryDefinition = new QueryDefinition(sqlQuery)
+                .WithParameter("@id", id)
+                .WithParameter("@pk", partitionKey);
+            
+            TestDocument documentToDelete = null;
+            using (var iterator = container.GetItemQueryIterator<TestDocument>(queryDefinition))
+            {
+                var response = await iterator.ReadNextAsync();
+                documentToDelete = response.FirstOrDefault();
+            }
+            
+            if (documentToDelete == null)
+            {
+                Console.WriteLine($"Document with id {id} not found!");
+                return;
+            }
+            
+            // Create hierarchical partition key
+            PartitionKey hierarchicalPK = new PartitionKeyBuilder()
+                .Add(partitionKey)
+                .Add(documentToDelete.Queryfield)
+                .Build();
+            
             // Delete the document
             ItemResponse<TestDocument> deleteResponse = await container.DeleteItemAsync<TestDocument>(
                 id: id,
-                partitionKey: new PartitionKey(partitionKey)
+                partitionKey: hierarchicalPK
             );
             
             Console.WriteLine($"Deleted document - Status: {deleteResponse.StatusCode}");
@@ -259,7 +320,7 @@ public class CosmosDbDemo
             {
                 ItemResponse<TestDocument> verifyResponse = await container.ReadItemAsync<TestDocument>(
                     id: id,
-                    partitionKey: new PartitionKey(partitionKey)
+                    partitionKey: hierarchicalPK
                 );
                 
                 // If we get here, deletion failed
@@ -282,22 +343,27 @@ public class CosmosDbDemo
 
     private async Task QueryDocumentsByPartitionKeyAsync(Container container, string partitionKey)
     {
-        Console.WriteLine($"Querying documents with partition key: {partitionKey}");
+        Console.WriteLine($"Querying documents with primary partition key: {partitionKey}");
         
-        // Query documents using LINQ with a partition key filter
-        var queryable = container.GetItemLinqQueryable<TestDocument>(
-            allowSynchronousQueryExecution: true,
-            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) }
-        );
+        // Query documents using SQL with partition key filter (works with hierarchical keys)
+        string sqlQuery = "SELECT * FROM c WHERE c.pk = @pk";
+        QueryDefinition queryDefinition = new QueryDefinition(sqlQuery)
+            .WithParameter("@pk", partitionKey);
         
         int count = 0;
-        foreach (var document in queryable)
+        using (var iterator = container.GetItemQueryIterator<TestDocument>(queryDefinition))
         {
-            Console.WriteLine($"Found document: Id={document.Id}, Queryfield={document.Queryfield}, PartitionKey={document.PartitionKey}, City={document.City}");
-            count++;
+            while (iterator.HasMoreResults)
+            {
+                foreach (var document in await iterator.ReadNextAsync())
+                {
+                    Console.WriteLine($"Found document: Id={document.Id}, Queryfield={document.Queryfield}, PartitionKey={document.PartitionKey}, City={document.City}");
+                    count++;
+                }
+            }
         }
         
-        Console.WriteLine($"Found {count} document(s) with partition key {partitionKey}");
+        Console.WriteLine($"Found {count} document(s) with primary partition key {partitionKey}");
     }
 
     private async Task QueryAllDocumentsAsync(Container container)
@@ -321,5 +387,208 @@ public class CosmosDbDemo
         }
         
         Console.WriteLine($"Found {count} document(s) in total");
+    }
+
+    private async Task QueryDocumentsWithOrderByAsync(Container container)
+    {
+        Console.WriteLine("\nQuerying documents ordered by City...");
+        
+        string sqlQuery = "SELECT * FROM c WHERE c.pk = @pk ORDER BY c.City";
+        var queryDefinition = new QueryDefinition(sqlQuery)
+            .WithParameter("@pk", "p1");
+        var queryOptions = new QueryRequestOptions { MaxItemCount = 10 };
+        
+        int count = 0;
+        
+        Console.WriteLine("Results in ascending order by City:");
+        using (var iterator = container.GetItemQueryIterator<TestDocument>(
+            queryDefinition, 
+            requestOptions: queryOptions))
+        {
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync();             
+                foreach (var document in response)
+                {
+                    Console.WriteLine($"Found document: Id={document.Id}, City={document.City}, PartitionKey={document.PartitionKey}");
+                    count++;
+                }
+            }
+        }
+        
+        Console.WriteLine($"Found {count} document(s) in total");
+       
+        // Also demonstrate descending order
+        count = 0;
+        
+        Console.WriteLine("\nResults in descending order by City:");
+        sqlQuery = "SELECT * FROM c WHERE c.pk = @pk ORDER BY c.City DESC";
+        queryDefinition = new QueryDefinition(sqlQuery)
+            .WithParameter("@pk", "p1");
+        
+        using (var iterator = container.GetItemQueryIterator<TestDocument>(
+            queryDefinition, 
+            requestOptions: queryOptions))
+        {
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync();               
+                foreach (var document in response)
+                {
+                    Console.WriteLine($"Found document: Id={document.Id}, City={document.City}, PartitionKey={document.PartitionKey}");
+                    count++;
+                }
+            }
+        }
+        
+        Console.WriteLine($"Found {count} document(s) in total");
+    }
+
+    private async Task RunChangeFeedDemoAsync(Container container)
+    {
+        Console.WriteLine("=== Change Feed Demo ===");
+        
+        // Create some test documents for change feed
+        Console.WriteLine("Creating additional test documents for change feed...");
+        await CreateMultipleTestDocumentsAsync(container, 5);
+        
+        Console.WriteLine("\nTesting Change Feed - Latest Versions Mode from Beginning...");
+        await TestChangeFeedLatestVersionsModeAsync(container);
+        
+        Console.WriteLine("\nModifying documents and testing incremental change feed...");
+        await ModifyDocumentsAndTestIncrementalChangeFeedAsync(container);
+    }
+
+    private async Task CreateMultipleTestDocumentsAsync(Container container, int documentCount)
+    {
+        Console.WriteLine($"Creating {documentCount} test documents...");
+        
+        for (int i = 0; i < documentCount; i++)
+        {
+            string id = $"changefeed-doc-{i}";
+            string partitionKey = $"pk-{i % 2}"; // Distribute across 2 partition keys
+            string queryField = $"field-{i}";
+            string city = $"City-{i}";
+            
+            await CreateDocumentAsync(container, id, queryField, partitionKey, city);
+        }
+        
+        Console.WriteLine($"Created {documentCount} test documents successfully");
+    }
+
+    private async Task TestChangeFeedLatestVersionsModeAsync(Container container)
+    {
+        Console.WriteLine("Testing Change Feed Latest Versions Mode from Beginning...");
+        
+        string continuationToken = null;
+        int pageHintSize = 2;
+        
+        using FeedIterator<TestDocument> feedIterator = container.GetChangeFeedIterator<TestDocument>(
+            ChangeFeedStartFrom.Beginning(),
+            ChangeFeedMode.LatestVersion,
+            new ChangeFeedRequestOptions { PageSizeHint = pageHintSize });
+
+        int maxDocCountReturnedPerRequest = 0;
+        List<TestDocument> changedDocuments = new List<TestDocument>();
+        int pageCount = 0;
+        
+        while (feedIterator.HasMoreResults)
+        {
+            FeedResponse<TestDocument> response = await feedIterator.ReadNextAsync();
+            pageCount++;
+            
+            Console.WriteLine($"Page {pageCount}: Status Code = {response.StatusCode}");
+            
+            if (response.StatusCode == HttpStatusCode.NotModified)
+            {
+                Console.WriteLine("No more changes available - received NotModified status");
+                break;
+            }
+            else
+            {
+                int docCount = 0;
+                foreach (var item in response)
+                {
+                    changedDocuments.Add(item);
+                    Console.WriteLine($"  Changed document: Id={item.Id}, City={item.City}, PartitionKey={item.PartitionKey}");
+                    docCount++;
+                }
+                maxDocCountReturnedPerRequest = Math.Max(maxDocCountReturnedPerRequest, docCount);
+                Console.WriteLine($"  Documents in this page: {docCount}");
+            }
+            continuationToken = response.ContinuationToken;
+        }
+
+        Console.WriteLine($"Change Feed Summary:");
+        Console.WriteLine($"  Total documents retrieved: {changedDocuments.Count}");
+        Console.WriteLine($"  Max documents per request: {maxDocCountReturnedPerRequest}");
+        Console.WriteLine($"  Total pages processed: {pageCount}");
+        Console.WriteLine($"  Final continuation token: {continuationToken?.Substring(0, Math.Min(50, continuationToken.Length))}...");
+    }
+
+    private async Task ModifyDocumentsAndTestIncrementalChangeFeedAsync(Container container)
+    {
+        Console.WriteLine("Setting up change feed iterator from Now...");
+        
+        // Create iterator starting from Now to catch only new changes
+        using FeedIterator<TestDocument> feedIterator = container.GetChangeFeedIterator<TestDocument>(
+            ChangeFeedStartFrom.Now(),
+            ChangeFeedMode.LatestVersion,
+            new ChangeFeedRequestOptions { PageSizeHint = 5 });
+
+        // First, drain any existing changes (should be empty since we're starting from Now)
+        Console.WriteLine("Draining existing changes (should be none)...");
+        await DrainChangeFeedAsync(feedIterator, "Initial drain");
+
+        // Now modify some documents
+        Console.WriteLine("\nModifying existing documents...");
+        await UpdateDocumentAndVerifyAsync(container, "changefeed-doc-0", "pk-0", "Modified-City-0");
+        await UpdateDocumentAndVerifyAsync(container, "changefeed-doc-1", "pk-1", "Modified-City-1");
+        
+        // Create a new document
+        await CreateDocumentAsync(container, "new-doc-after-changefeed", "new-field", "pk-0", "New-City");
+        
+        // Now check the change feed for these modifications
+        Console.WriteLine("\nChecking change feed for recent modifications...");
+        List<TestDocument> recentChanges = await DrainChangeFeedAsync(feedIterator, "After modifications");
+        
+        Console.WriteLine($"Found {recentChanges.Count} recent changes");
+        foreach (var doc in recentChanges)
+        {
+            Console.WriteLine($"  Recent change: Id={doc.Id}, City={doc.City}, PartitionKey={doc.PartitionKey}");
+        }
+    }
+
+    private async Task<List<TestDocument>> DrainChangeFeedAsync(FeedIterator<TestDocument> feedIterator, string context)
+    {
+        List<TestDocument> allChanges = new List<TestDocument>();
+        int pageCount = 0;
+        
+        Console.WriteLine($"Draining change feed ({context})...");
+        
+        while (feedIterator.HasMoreResults)
+        {
+            FeedResponse<TestDocument> response = await feedIterator.ReadNextAsync();
+            pageCount++;
+            
+            if (response.StatusCode == HttpStatusCode.NotModified)
+            {
+                Console.WriteLine($"  Page {pageCount}: No more changes (NotModified)");
+                break;
+            }
+            else
+            {
+                int docCount = 0;
+                foreach (var item in response)
+                {
+                    allChanges.Add(item);
+                    docCount++;
+                }
+                Console.WriteLine($"  Page {pageCount}: Found {docCount} changes");
+            }
+        }
+        
+        Console.WriteLine($"Completed draining change feed - Total: {allChanges.Count} documents, {pageCount} pages");
+        return allChanges;
     }
 }


### PR DESCRIPTION
In this PR, the following changes are made:

1. A method of RunChangeFeedDemoAsync is added dedicated to change feed operations.
2. The default partition key setting becomes hierarchical.

Expected demo results are:

Beginning CosmosDB Demo...
Creating database: db-ac44a058cb304752a6904468fdb10ea0
Database created with status: Created
Creating container: container-de411c34bc434c94b6b267b8440065ea
Container created with hierarchical partition keys - Status: Created
Creating documents...
Created document document1 with hierarchical partition key [p1, field1] - Status: Created
Created document document2 with hierarchical partition key [p2, field2] - Status: Created
Reading all documents unchanged...
Querying all documents...
Found document: Id=document1, Queryfield=field1, PartitionKey=p1, City=Seattle
Found document: Id=document2, Queryfield=field2, PartitionKey=p2, City=Portland
Found 2 document(s) in total

Updating document...
Updating document document1 with new city:
Retrieved document: Id=document1, City=Seattle, Queryfield=field1
Document with id document1 not found!

Upsert new document...
Upserting document document3 with hierarchical partition key [p2, field1]
Upserted document - Status: Created
Verifying upsert by reading the document:
Verified document: Id=document3, Queryfield=field1, PartitionKey=p2, City=New Orleans

Upsert existing document...
Upserting document document2 with hierarchical partition key [p2, field1]
Upserted document - Status: Created
Verifying upsert by reading the document:
Verified document: Id=document2, Queryfield=field1, PartitionKey=p2, City=Miami
Reading documents with partition key filter...
Querying documents with primary partition key: p1
Found document: Id=document1, Queryfield=field1, PartitionKey=p1, City=Seattle
Found 1 document(s) with primary partition key p1
Reading all documents...
Querying all documents...
Found document: Id=document1, Queryfield=field1, PartitionKey=p1, City=Seattle
Found document: Id=document2, Queryfield=field2, PartitionKey=p2, City=Portland
Found document: Id=document3, Queryfield=field1, PartitionKey=p2, City=New Orleans
Found document: Id=document2, Queryfield=field1, PartitionKey=p2, City=Miami
Found 4 document(s) in total

Querying documents with order by...

Querying documents ordered by City...
Results in ascending order by City:
Found document: Id=document1, City=Seattle, PartitionKey=p1
Found 1 document(s) in total

Results in descending order by City:
Found document: Id=document1, City=Seattle, PartitionKey=p1
Found 1 document(s) in total

Deleting document...
Deleting document document1 with partition key p1
Deleted document - Status: NoContent
Verifying deletion by attempting to read the document:
Verified: Document was successfully deleted (not found anymore)

Running Change Feed Demo...
=== Change Feed Demo ===
Creating additional test documents for change feed...
Creating 5 test documents...
Created document changefeed-doc-0 with hierarchical partition key [pk-0, field-0] - Status: Created
Created document changefeed-doc-1 with hierarchical partition key [pk-1, field-1] - Status: Created
Created document changefeed-doc-2 with hierarchical partition key [pk-0, field-2] - Status: Created
Created document changefeed-doc-3 with hierarchical partition key [pk-1, field-3] - Status: Created
Created document changefeed-doc-4 with hierarchical partition key [pk-0, field-4] - Status: Created
Created 5 test documents successfully

Testing Change Feed - Latest Versions Mode from Beginning...
Testing Change Feed Latest Versions Mode from Beginning...
Page 1: Status Code = OK
  Changed document: Id=document2, City=Portland, PartitionKey=p2
  Changed document: Id=document3, City=New Orleans, PartitionKey=p2
  Documents in this page: 2
Page 2: Status Code = OK
  Changed document: Id=document2, City=Miami, PartitionKey=p2
  Changed document: Id=changefeed-doc-0, City=City-0, PartitionKey=pk-0
  Documents in this page: 2
Page 3: Status Code = OK
  Changed document: Id=changefeed-doc-1, City=City-1, PartitionKey=pk-1
  Changed document: Id=changefeed-doc-2, City=City-2, PartitionKey=pk-0
  Documents in this page: 2
Page 4: Status Code = OK
  Changed document: Id=changefeed-doc-3, City=City-3, PartitionKey=pk-1
  Changed document: Id=changefeed-doc-4, City=City-4, PartitionKey=pk-0
  Documents in this page: 2
Page 5: Status Code = NotModified
No more changes available - received NotModified status
Change Feed Summary:
  Total documents retrieved: 8
  Max documents per request: 2
  Total pages processed: 5
  Final continuation token: {"V":2,"Rid":"MDAwOA==","Continuation":[{"FeedRang...

Modifying documents and testing incremental change feed...
Setting up change feed iterator from Now...
Draining existing changes (should be none)...
Draining change feed (Initial drain)...
  Page 1: Found 1 changes
  Page 2: No more changes (NotModified)
Completed draining change feed - Total: 1 documents, 2 pages

Modifying existing documents...
Updating document changefeed-doc-0 with new city: Modified-City-0
Retrieved document: Id=changefeed-doc-0, City=City-0, Queryfield=field-0
Document with id changefeed-doc-0 not found!
Updating document changefeed-doc-1 with new city: Modified-City-1
Retrieved document: Id=changefeed-doc-1, City=City-1, Queryfield=field-1
Document with id changefeed-doc-1 not found!
Created document new-doc-after-changefeed with hierarchical partition key [pk-0, new-field] - Status: Created

Checking change feed for recent modifications...
Draining change feed (After modifications)...
  Page 1: Found 1 changes
  Page 2: No more changes (NotModified)
Completed draining change feed - Total: 1 documents, 2 pages
Found 1 recent changes
  Recent change: Id=new-doc-after-changefeed, City=New-City, PartitionKey=pk-0
Cleaning up...
Demo completed successfully!